### PR TITLE
Fix names and links register screen

### DIFF
--- a/SIGS/app/views/users/new.html.erb
+++ b/SIGS/app/views/users/new.html.erb
@@ -36,7 +36,7 @@
           <fieldset id="type">
             <div class="radioButton">
               <input type="radio" name="type" value="administrative_assistant" id="adm_as" checked>
-              <label>assistante Administrativo</label>
+              <label>Assistente Administrativo</label>
             </div>
             <div class="radioButton">
               <input type="radio" name="type" value="deg" id="deg_user">

--- a/SIGS/app/views/users/new.html.erb
+++ b/SIGS/app/views/users/new.html.erb
@@ -70,6 +70,7 @@
 
           <div class="actions">
             <%= f.submit "Enviar", class: 'pull-right btn btn-default btn-success' %>
+            <%= link_to "Já está cadastrado? Fazer login...", root_path %>
           </div>
         </div>
       </div> <!-- ./row -->


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

## Porposed Changes
- [x] Rename **Assistente Administrativo** on new user screen  
- [x] Link to go back to login from register

## _Issue_ Related
#22 


## Screenshots

![image](https://user-images.githubusercontent.com/18387694/45623633-63de3800-ba5e-11e8-9411-965339328979.png)

![image](https://user-images.githubusercontent.com/18387694/45626009-b4f12a80-ba64-11e8-9b23-3674e62fc731.png)


