### PR TITLE
Makes code search field find with substrings

### DIFF
--- a/SIGS/app/helpers/rooms_helper.rb
+++ b/SIGS/app/helpers/rooms_helper.rb
@@ -29,6 +29,6 @@ module RoomsHelper
 
   def filter_by_code
     return unless params[:code].present?
-    @rooms = @rooms.where('rooms.code' => params[:code])
+    @rooms = @rooms.where('rooms.code LIKE ?', "%#{params[:code]}%")
   end
 end

--- a/SIGS/app/views/rooms/index.html.erb
+++ b/SIGS/app/views/rooms/index.html.erb
@@ -1,5 +1,6 @@
 <h1>Salas</h1>
 <table class="table">
+
   <tr>
   <%= form_tag(room_index_post_path, :method => :post) do %>
     <td>
@@ -43,14 +44,14 @@
         <span class="fa fa-search"></span> Pesquisar
       <% end %>
     </td>
-    <td colspan="2">
+    <td>
       <br>
       <%= link_to room_index_path, class: "btn btn-primary pull-right" do %>
         <span class="fa fa-eraser"></span> Limpar Filtros
       <% end %>
     </td>
   </tr>
-
+  
 <% end %>
 
 </table>


### PR DESCRIPTION
# Porposed Changes
Code search field was not finding subcode.
if the user search for code 123456 and type 12 nothing will be shown, now its showing.

# Type of Changes
- [x] Search with substrings

# Checklist 
- [x] This Pull Request has a significant name.
- [x] The commits follow the [[commits policy]].
- [x] The build is okay (tests, code climate).
- [x] This Pull Request mentions a related issue.
- [x] The change was necessary to the progress of the project.

