### PR TITLE
Fix #84 - User Edit

### DIFF
--- a/SIGS/app/views/users/edit.html.erb
+++ b/SIGS/app/views/users/edit.html.erb
@@ -1,6 +1,5 @@
 <h1>Perfil</h1>
 
-
       <%= form_for @user,:url => {:action=> "update"} do |user| %>
 
         <%= user.label :name, "E-mail" %>
@@ -19,13 +18,13 @@
         <%= user.file_field :image, class: "form-control" %><br>
 
         <%= user.label :password, "Senha: " %>
-        <%= user.password_field :password, class: "form-control", placeholder: "Digite sua senha" %><br>
+        <%= user.password_field :password, class: "form-control", placeholder: "Digite sua senha", :required => true %><br>
 
         <label for="confirm_password">Confirmar Senha: </label>
-        <input type="password" name="confirm_password" id="confirm_password" class= "form-control" placeholder= "Digite sua senha"/>
+        <input type="password" name="confirm_password" id="confirm_password" class= "form-control" placeholder= "Confirme sua senha" required/>
 
         <div class="actions">
-          <%= user.submit "Salvar", class: "pull-right btn btn-default btn-success" %>
+          <%= user.submit "Salvar", class: "pull-right btn btn-default btn-success", data: {confirm: "Deseja continuar com esta ação? \n\nLembre-se que para editar o seu usuário é necessário colocar a sua senha!"} %>
           <%= link_to "Excluir Conta", user_destroy_path, class: "btn btn-default btn-danger", data: {confirm: "Esta ação não poderá mais ser desfeita. Tem certeza que deseja continuar?"} %>
         </div>
       </div>


### PR DESCRIPTION
Adds required to password fields on edit view

Adds a confirm message to edit with a message to type the password

Signed-off-by: João Pedro Sconetto <sconetto.joao@gmail.com>

## Proposed Changes
Adds front-end modification requiring the password and adding a message to the user to confirm the edition

## _Issue_ Related
#84 

## Type of Changes

- [ ] New backend feature or update.
- [x] New frontend feature or update.
- [x] Bug fix.
- [ ] Another change (what was the change?).

## How Was This Tested?
Was tested locally

## Checklist

- [x] This Pull Request has a significant name.
- [x] The commits follow the [[commits policy]].
- [ ] The build is okay (tests, code climate).
- [x] This Pull Request mentions a related issue.
- [x] The change was necessary to the progress of the project.

## Screenshots
Not apply

## Further comments
Nothing to add